### PR TITLE
Suggestion for path/file set at the .dephpugger.yml preferences

### DIFF
--- a/console/ServerCommand.php
+++ b/console/ServerCommand.php
@@ -33,16 +33,16 @@ class ServerCommand extends Command
         $debuggerHost = $config->debugger['host'];
         $debuggerPort = $config->debugger['port'];
         $path = $config->server['path'] == null ? '' : $config->server['path'];
-        $file = $config->server['file'] !== '' ? $path.$config->server['file'] : '';
+        $file = $config->server['file'] == null ? '' : $config->server['file'];
 
         $pathWithParam = $path != '' ? "-t $path" : '';
 
         $command = "{$phpPath} -S {$defaultHost}:{$defaultPort} ";
-        $command .= "-t {$projectPath} ";
+        $command .= $pathWithParam !== '' ? $pathWithParam : "-t {$projectPath} ";
         $command .= '-dxdebug.remote_enable=1 -dxdebug.remote_mode=req ';
         $command .= "-dxdebug.remote_port={$debuggerPort} ";
         $command .= "-dxdebug.remote_host={$debuggerHost} -dxdebug.remote_connect_back=0 ";
-        $command .= "{$pathWithParam} {$file}";
+        $command .= $path !== '' && $file !== '' ? $path.$file : '';
 
         $output->write(splashScreen());
         $output->writeln("Running command: <fg=red>{$command}</>\n");


### PR DESCRIPTION
So, first of all, thanks so much for this package. I consider a great idea, I coming from ruby on rails and one tool like byebug was all what I wanted for my web applications in php, most specifically, in Laravel.

Well, this change is just an detail that I have figured when I tried use the preferences in .dephpugger.yml file, related to the path passed at the `-t` parameter. When I used the path param in the .dephpugger.yml, it was duplicated with the variable `$projetcPath`.

With this preferences: 
```
debugger: 
  host: localhost                                 # default: localhost
  port: 9002                                       # default: 9005
  lineOffset: 10                                  # default: 6
  verboseMode: false                         # default: false
  historyFile: ~/.dephpugger_history # default: .dephpugger_history
server:
  port: 8080                                       # default: 8888
  host: localhost                                # default: localhost
  path: ./public/                                 # defautl: null
  file:  index.php                                # default: null
  phpPath: /usr/bin/php                     # default: php

```

...something like that was returned:
`/usr/bin/php -S localhost:8080 -t ./public/ -dxdebug.remote_enable=1 -dxdebug.remote_mode=req -dxdebug.remote_port=9002 -dxdebug.remote_host=localhost -dxdebug.remote_connect_back=0 -t ./public/  ./public/index.php`

...and now:
`/usr/bin/php -S localhost:8080 -t ./public/ -dxdebug.remote_enable=1 -dxdebug.remote_mode=req -dxdebug.remote_port=9002 -dxdebug.remote_host=localhost -dxdebug.remote_connect_back=0 ./public/index.php`

I hope this can be really useful :)

PS: Sorry for my bad english :-P