### PR TITLE
Fix binary to be used on development enviroment

### DIFF
--- a/bin/dephpugger
+++ b/bin/dephpugger
@@ -3,7 +3,6 @@
 
 $autoloads = [
     dirname(dirname(dirname(dirname(__DIR__)))) . DIRECTORY_SEPARATOR,
-    
 ];
 
 // Checking if file is found
@@ -59,31 +58,4 @@ includePaths($paths);
 
 // Create application
 $application = new Symfony\Component\Console\Application();
-
-// Paths to console
-$paths = [
-    implode(DIRECTORY_SEPARATOR, ['console', '*.php']),
-    implode(DIRECTORY_SEPARATOR, ['console', 'concerns', '*.php'])
-];
-includePaths($paths, $application);
-
-// Function to splash screen
-function splashScreen($word='Server') {
-    $version = 'v' . Dephpug\Dephpugger::$VERSION;
-    return <<<EOL
-<info>
-  _____             _                                       
- |  __ \           | |                                      
- | |  | | ___ _ __ | |__  _ __  _   _  __ _  __ _  ___ _ __ 
- | |  | |/ _ \ '_ \| '_ \| '_ \| | | |/ _` |/ _` |/ _ \ '__|
- | |__| |  __/ |_) | | | | |_) | |_| | (_| | (_| |  __/ |   
- |_____/ \___| .__/|_| |_| .__/ \__,_|\__, |\__, |\___|_|   
-             | |         | |           __/ | __/ |          
-             |_|         |_|          |___/ |___/           </info>
-
-                                   $word - Version: <fg=cyan>$version</>
-
-EOL;
-}
-
 $application->run();

--- a/bin/dephpugger
+++ b/bin/dephpugger
@@ -1,61 +1,32 @@
 #!/usr/bin/env php
 <?php
 
-$autoloads = [
-    dirname(dirname(dirname(dirname(__DIR__)))) . DIRECTORY_SEPARATOR,
+$availableAutoloadPaths = [
+    __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'autoload.php',
+    __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php',
+    __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php',
 ];
 
-// Checking if file is found
-$dirPath = false;
-foreach($autoloads as $path) {
-    $autoload = $path . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
-    if(file_exists($autoload)) {
-        require_once $autoload;
-        $dirPath = $path;
+foreach ($availableAutoloadPaths as  $availableAutoloadPath) {
+    if (file_exists($availableAutoloadPath)) {
+        $autoloadPath = $availableAutoloadPath;
         break;
     }
 }
 
-// If not found, get message error
-if(!$dirPath) {
-    echo "Cannot find autoload.php in folders: \n";
-    foreach($autoloads as $autoload) {
-        echo " - {$autoload}" . 'vendor' . DIRECTORY_SEPARATOR . "autoload.php\n";
-    }
+if (!isset($autoloadPath)) {
+    fwrite(
+        STDERR,
+        'You need to set up the project dependencies using Composer:' . PHP_EOL . PHP_EOL .
+        '    composer install' . PHP_EOL . PHP_EOL .
+        'You can learn all about Composer on https://getcomposer.org/.' . PHP_EOL
+    );
 
-    echo 'You must run `composer install` first.';
-    exit;
+    die(1);
 }
 
-// Folder vendor/ in project found
-define('VENDORDIR', $dirPath.'vendor'.DIRECTORY_SEPARATOR.'tacnoman'.DIRECTORY_SEPARATOR.'dephpugger'.DIRECTORY_SEPARATOR);
-
-/**
- * Function to include paths
- */
-function includePaths($arrayOfPaths, &$application=null)
-{
-    $paths = [];
-    foreach($arrayOfPaths as $path) {
-        $pathFile = VENDORDIR.$path;
-        $files = glob($pathFile);
-        $paths = array_merge($paths, $files);
-    }
-
-    foreach($paths as $path)
-    {
-        require_once $path;
-    }
-}
-
-// Paths to load all classes in src/Dephpug (like psr-0)
-$paths = [
-    implode(DIRECTORY_SEPARATOR, ['src', 'Dephpug', '***.php']),
-    implode(DIRECTORY_SEPARATOR, ['src', 'Dephpug', '**', '*.php']),
-    implode(DIRECTORY_SEPARATOR, ['src', 'Dephpug', '**', '**', '*.php']),
-];
-includePaths($paths);
+require $autoloadPath;
 
 // Create application
-$application = new Symfony\Component\Console\Application();
+$application = new Dephpug\Dephpugger();
 $application->run();

--- a/bin/dephpugger
+++ b/bin/dephpugger
@@ -8,9 +8,9 @@ $availableAutoloadPaths = [
     __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php',
 ];
 
-foreach ($availableAutoloadPaths as  $availableAutoloadPath) {
-    if (file_exists($availableAutoloadPath)) {
-        $autoloadPath = $availableAutoloadPath;
+foreach ($availableAutoloadPaths as $currentAvailableAutoloadPath) {
+    if (file_exists($currentAvailableAutoloadPath)) {
+        $autoloadPath = $currentAvailableAutoloadPath;
         break;
     }
 }

--- a/bin/dephpugger
+++ b/bin/dephpugger
@@ -2,6 +2,7 @@
 <?php
 
 $availableAutoloadPaths = [
+    __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'autoload.php',
     __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'autoload.php',
     __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php',
     __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php',

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,9 @@
     "squizlabs/php_codesniffer": "2.*"
   },
   "autoload": {
-    "psr-0" : {
-      "Dephpug\\": "src/Dephpug"
+    "psr-4" : {
+      "Dephpug\\": "src/Dephpug",
+      "Dephpug\\Console\\": "console/"
     },
     "files": [
       "src/Dephpug/SplashScreen.php"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,10 @@
   "autoload": {
     "psr-0" : {
       "Dephpug\\": "src/Dephpug"
-    }
+    },
+    "files": [
+      "src/Dephpug/SplashScreen.php"
+    ]
   },
   "bin": ["bin/dephpugger"],
   "license": "MIT",

--- a/console/CliCommand.php
+++ b/console/CliCommand.php
@@ -43,5 +43,3 @@ class CliCommand extends Command
         passthru($command);
     }
 }
-
-$application->add(new CliCommand());

--- a/console/DebuggerCommand.php
+++ b/console/DebuggerCommand.php
@@ -43,5 +43,3 @@ class DebuggerCommand extends Command
         }
     }
 }
-
-$application->add(new DebuggerCommand());

--- a/console/DebuggerCommand.php
+++ b/console/DebuggerCommand.php
@@ -9,6 +9,8 @@ use Dephpug\Dephpugger;
 use Dephpug\Exception\ExitProgram;
 use Dephpug\Config;
 
+use function Dephpug\SplashScreen;
+
 class DebuggerCommand extends Command
 {
     protected function configure()

--- a/console/InfoCommand.php
+++ b/console/InfoCommand.php
@@ -40,5 +40,3 @@ class InfoCommand extends Command
         }
     }
 }
-
-$application->add(new InfoCommand());

--- a/console/RequirementsCommand.php
+++ b/console/RequirementsCommand.php
@@ -40,5 +40,3 @@ class RequirementsCommand extends Command
         $output->writeln($phpInfo->printVar('xdebug.default_enable', 'XDebug default_enable'));
     }
 }
-
-$application->add(new RequirementsCommand());

--- a/console/ServerCommand.php
+++ b/console/ServerCommand.php
@@ -8,6 +8,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Dephpug\Config;
 use Dephpug\Dephpugger;
 
+use function Dephpug\SplashScreen;
+
 class ServerCommand extends Command
 {
     protected function configure()

--- a/console/ServerCommand.php
+++ b/console/ServerCommand.php
@@ -53,5 +53,3 @@ class ServerCommand extends Command
         shell_exec($command);
     }
 }
-
-$application->add(new ServerCommand());

--- a/src/Dephpug/Dephpugger.php
+++ b/src/Dephpug/Dephpugger.php
@@ -2,6 +2,8 @@
 
 namespace Dephpug;
 
+use Symfony\Component\Console\Application;
+
 /**
  * Class indicates info about the project
  */
@@ -9,4 +11,23 @@ class Dephpugger
 {
     /** The version of the Dephpugger */
     public static $VERSION = '1.1.2';
+
+    protected $commands = [
+        \Dephpug\Console\CliCommand::class,
+        \Dephpug\Console\DebuggerCommand::class,
+        \Dephpug\Console\InfoCommand::class,
+        \Dephpug\Console\RequirementsCommand::class,
+        \Dephpug\Console\ServerCommand::class,
+    ];
+
+    public function run()
+    {
+        $application = new Application();
+
+        foreach ($this->commands as $command) {
+            $application->add(new $command);
+        }
+
+        return $application->run();
+    }
 }

--- a/src/Dephpug/SplashScreen.php
+++ b/src/Dephpug/SplashScreen.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Dephpug;
+
+// Function to splash screen
+function splashScreen($word='Server') {
+    $version = 'v' . \Dephpug\Dephpugger::$VERSION;
+    return <<<EOL
+<info>
+  _____             _                                       
+ |  __ \           | |                                      
+ | |  | | ___ _ __ | |__  _ __  _   _  __ _  __ _  ___ _ __ 
+ | |  | |/ _ \ '_ \| '_ \| '_ \| | | |/ _` |/ _` |/ _ \ '__|
+ | |__| |  __/ |_) | | | | |_) | |_| | (_| | (_| |  __/ |   
+ |_____/ \___| .__/|_| |_| .__/ \__,_|\__, |\__, |\___|_|   
+             | |         | |           __/ | __/ |          
+             |_|         |_|          |___/ |___/           </info>
+
+                                   $word - Version: <fg=cyan>$version</>
+
+EOL;
+}


### PR DESCRIPTION
## What this PR do?
Basically, this PR remove responsibility of check and include files from `bin/dephpugger` file. Its done adding avoid directories to `composer.json` and separate some functions to its specific files. Also change way that `autoload.php` file is added.

## What this PR solve?
Fix #16.

Sorry for my english, if something is not so clearly, I'm open to discuss.