### PR TITLE
Add space before concat xdebug params and params on .dephpugger.yml

### DIFF
--- a/console/ServerCommand.php
+++ b/console/ServerCommand.php
@@ -39,9 +39,9 @@ class ServerCommand extends Command
 
         $command = "{$phpPath} -S {$defaultHost}:{$defaultPort} ";
         $command .= $pathWithParam !== '' ? $pathWithParam : "-t {$projectPath} ";
-        $command .= '-dxdebug.remote_enable=1 -dxdebug.remote_mode=req ';
-        $command .= "-dxdebug.remote_port={$debuggerPort} ";
-        $command .= "-dxdebug.remote_host={$debuggerHost} -dxdebug.remote_connect_back=0 ";
+        $command .= ' -dxdebug.remote_enable=1 -dxdebug.remote_mode=req ';
+        $command .= " -dxdebug.remote_port={$debuggerPort} ";
+        $command .= " -dxdebug.remote_host={$debuggerHost} -dxdebug.remote_connect_back=0 ";
         $command .= $path !== '' && $file !== '' ? $path.$file : '';
 
         $output->write(splashScreen());


### PR DESCRIPTION
## What this PR do?
Add space between params loaded from `.dephpugger.yml` file and default xdebug params.

## What this PR solve?
When command `debugger server` is executed with `.dephpugger.yml` file and
param `path` is defined, the concat that is done creates problems
because has on spece between params. For example:

Running dephpugger without `.dephpugger.yml` file:

Running command: /usr/local/bin/php -S localhost:8888 **-t /home/ricardo/Projetos/dephpugger -dxdebug.remote_enable=1** -dxdebug.remote_mode=req -dxdebug.remote_port=9005 -dxdebug.remote_host=localhost -dxdebug.remote_connect_back=0 

Running dephpugger with .dephpugger.yml file:

Running command: /usr/local/bin/php -S 0.0.0.0:8888 **-t ./public/-dxdebug.remote_enable=1 -dxdebug.remote_mode=req** -dxdebug.remote_port=9005 -dxdebug.remote_host=0.0.0.0 -dxdebug.remote_connect_back=0 ./public/index.php

Solve #15 