### PR TITLE
Add plugins in composer autoload file list

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,25 @@
       "Dephpug\\Console\\": "console/"
     },
     "files": [
-      "src/Dephpug/SplashScreen.php"
+      "src/Dephpug/SplashScreen.php",
+      "src/Dephpug/Command/ContinueCommand.php",
+      "src/Dephpug/Command/DbgpCommand.php",
+      "src/Dephpug/Command/EvalCommand.php",
+      "src/Dephpug/Command/GetValueCommand.php",
+      "src/Dephpug/Command/HelpCommand.php",
+      "src/Dephpug/Command/ListCommand.php",
+      "src/Dephpug/Command/ListPreviousCommand.php",
+      "src/Dephpug/Command/NextCommand.php",
+      "src/Dephpug/Command/QuitCommand.php",
+      "src/Dephpug/Command/SetCommand.php",
+      "src/Dephpug/Command/SetValueCommand.php",
+      "src/Dephpug/Command/StepIntoCommand.php",
+      "src/Dephpug/Parser/CloseMessageEvent.php",
+      "src/Dephpug/Parser/ErrorMessageEvent.php",
+      "src/Dephpug/Parser/FilePrinterMessageEvent.php",
+      "src/Dephpug/Parser/InitMessageEvent.php",
+      "src/Dephpug/Parser/PropertyGetMessageEvent.php",
+      "src/Dephpug/Parser/VerboseModeMessageParse.php"
     ]
   },
   "bin": ["bin/dephpugger"],


### PR DESCRIPTION
## What this PR do?
Force to declare plugin classes adding source files into file list of autoload section in composer.json.

## What this PR solve?
The plugins are loaded dynamically using `get_declared_class` function. The problem is that these class will never be until be used.

This commit just add this files in composer autoload files to be declared when autoload.php be included.

This problem was referenced in #20 