### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM php:7-zts-alpine
+
+RUN apk --update --no-cache add autoconf g++ make && \
+pecl install -f xdebug-beta && \
+docker-php-ext-enable xdebug && \
+apk del --purge autoconf g++ make
+
+ENV HOME /root
+ENV COMPOSER_HOME $HOME/.composer
+ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
+ENV COMPOSER_ALLOW_SUPERUSER 1
+RUN curl -sSL -o /tmp/composer-setup.php https://getcomposer.org/installer \
+  && curl -sSL -o /tmp/composer-setup.sig https://composer.github.io/installer.sig \
+  && php -r "if (hash('SHA384', file_get_contents('/tmp/composer-setup.php')) !== trim(file_get_contents('/tmp/composer-setup.sig'))) { unlink('/tmp/composer-setup.php'); echo 'Invalid installer' . PHP_EOL; exit(1); }" \
+  && php /tmp/composer-setup.php --no-ansi --install-dir=/usr/local/bin --filename=composer --snapshot && rm -rf /tmp/composer-setup.php
+
+RUN composer global require tacnoman/dephpugger
+ENV PATH=$PATH:$COMPOSER_HOME/vendor/bin
+
+RUN composer global dump-autoload
+
+RUN curl -sSL -o $HOME/.composer/vendor/tacnoman/dephpugger/bin/dephpugger https://raw.githubusercontent.com/tacnoman/dephpugger/94246836f253a5a0798dac58b009d883abf3d72c/bin/dephpugger
+
+EXPOSE 8888
+
+CMD ["dephpugger", "server"]

--- a/bin/dephpugger
+++ b/bin/dephpugger
@@ -1,47 +1,26 @@
 #!/usr/bin/env php
 <?php
 
-$availableAutoloadPaths = explode(DIRECTORY_SEPARATOR, __DIR__);
-$autoloadFile = false;
-
-while(array_pop($availableAutoloadPaths)) {
-    $possibleRootPath = implode(DIRECTORY_SEPARATOR, $availableAutoloadPaths);
-    $autoloadFile = $possibleRootPath . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
-
-    if(file_exists($autoloadFile)) {
-        break;
-    }
+function findInnerPart($search, $parts=[]) {
+        do {
+                $part = array_pop($parts);
+        } while(($part != $search) && (count($parts) > 1));
+        return implode(DIRECTORY_SEPARATOR, $parts);
 }
 
-if (!$autoloadFile) {
-    fwrite(
-        STDERR,
-        'You need to set up the project dependencies using Composer:' . PHP_EOL . PHP_EOL .
-        '    composer install' . PHP_EOL . PHP_EOL .
-        'You can learn all about Composer on https://getcomposer.org/.' . PHP_EOL
-    );
-
-    die(1);
+function autoload_path($dir) {
+        $pathParts = explode(DIRECTORY_SEPARATOR, $dir);
+        if(in_array('vendor', $pathParts, true)) {
+                return findInnerPart('vendor', $pathParts);
+        } else if(in_array('bin', $pathParts, true)) {
+                return findInnerPart('bin', $pathParts);
+        }
+        throw new Exception("Can't find any base-paths. Please keep file within repository");
 }
 
-require $autoloadFile;
+$basePath = autoload_path(__DIR__);
 
-define('VENDORDIR', __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR);
-
-$paths = [
-    implode(DIRECTORY_SEPARATOR, ['src', 'Dephpug', '**.php']),
-    implode(DIRECTORY_SEPARATOR, ['src', 'Dephpug', '**', '*.php']),
-    implode(DIRECTORY_SEPARATOR, ['src', 'Dephpug', '**', '**', '*.php']),
-];
-
-foreach($paths as $path) {
-    $pathFile = VENDORDIR . $path;
-    $files = glob($pathFile);
-
-    foreach($files as $file) {
-        require_once $file;
-    }
-}
+require_once implode(DIRECTORY_SEPARATOR, [$basePath, 'vendor', 'autoload.php']);
 
 // Create application
 $application = new Dephpug\Dephpugger();


### PR DESCRIPTION
This uses #29 to patch `dephpugger` to work from it's `/bin/dephpugger` entrypoint

Added `Dockerfile` which can be built with

```
docker build -t dephpugger:latest .
```

and then run with

```
docker run --rm dephpugger:latest dephpugger requirements
```

It's default command is to start a server, `dephpugger` is in the `$PATH` so can be run using just the command line as-per `README.md`